### PR TITLE
Fix 04_controlling_mix runtime

### DIFF
--- a/flutter/.gitignore
+++ b/flutter/.gitignore
@@ -2,3 +2,4 @@
 */ios
 */web
 */mac
+**/.idea

--- a/flutter/04_controlling_mix/pubspec.lock
+++ b/flutter/04_controlling_mix/pubspec.lock
@@ -37,9 +37,11 @@ packages:
   rive:
     dependency: "direct main"
     description:
-      path: "../../../runtimes/rive-flutter"
-      relative: true
-    source: path
+      path: "."
+      ref: "66305cb511f4787c3b6cecb09c15b18bd9c5149d"
+      resolved-ref: "66305cb511f4787c3b6cecb09c15b18bd9c5149d"
+      url: "https://github.com/rive-app/rive-flutter"
+    source: git
     version: "0.6.3"
   sky_engine:
     dependency: transitive

--- a/flutter/04_controlling_mix/pubspec.yaml
+++ b/flutter/04_controlling_mix/pubspec.yaml
@@ -9,7 +9,11 @@ dependencies:
   flutter:
     sdk: flutter
   rive:
-    path: ../../../runtimes/rive-flutter
+    # Until the new version of `rive` for Flutter is published, we depend on the Git commit.
+    # See https://github.com/rive-app/rive-flutter/commit/66305cb511f4787c3b6cecb09c15b18bd9c5149d.
+    git:
+      url: https://github.com/rive-app/rive-flutter
+      ref: 66305cb511f4787c3b6cecb09c15b18bd9c5149d
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
I saw that only https://github.com/rive-app/rive-flutter/commit/66305cb511f4787c3b6cecb09c15b18bd9c5149d exposed the mix, which is required for the `04_controlling_mix` example.

I think that until that version is published, we want to use a Git dependency, so that others are able to run the example easily :)